### PR TITLE
Feature/1.19.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Nick AFK Party Pack
 
-Small Spigot plugin coded up in a day to add nicknames and AFK status for Minecraft 1.18.
+Small Spigot plugin coded up in a day to add nicknames and AFK status for Minecraft 1.19.3.
 
 Download on DevBukkit: https://dev.bukkit.org/projects/nick-afk-party-pack
 
-### [REQUIRES PROTOCOLLIB (DEV BUILD FOR 1.18)](https://www.spigotmc.org/resources/protocollib.1997/)
+### [REQUIRES PROTOCOLLIB (DEV BUILD FOR 1.19.3)](https://www.spigotmc.org/resources/protocollib.1997/)
 
 ![](https://i.imgur.com/GhYkvBx.png)
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ml.noahc3</groupId>
     <artifactId>NickAfkPartyPack</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 
     <repositories>
         <repository>
@@ -23,12 +23,12 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.8.0</version>
+            <version>5.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18.2-R0.1-SNAPSHOT</version>
+            <version>1.19.3-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.8.0-SNAPSHOT</version>
+            <version>4.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18.1-R0.1-SNAPSHOT</version>
+            <version>1.18.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/ml/noahc3/nickafkpartypack/Events/EventListener.java
+++ b/src/main/java/ml/noahc3/nickafkpartypack/Events/EventListener.java
@@ -28,8 +28,9 @@ public class EventListener implements Listener {
     }
 
     public static void SlowTick() {
-        long afkTime = Constants.config.getInt("auto-afk-time-seconds") * 1000L;
-        long kickTime = Constants.config.getInt("afk-kick-time-seconds") * 1000L;
+        final long afkTime = Constants.config.getInt("auto-afk-time-seconds") * 1000L;
+        final long kickTime = Constants.config.getInt("afk-kick-time-seconds") * 1000L;
+        final long now = System.currentTimeMillis();
 
         for(UUID u : Constants.afkTimestamps.keySet()) {
             Player player = Bukkit.getPlayer(u);
@@ -40,9 +41,10 @@ public class EventListener implements Listener {
                 updatePlayerStamps(player);
             }
 
-            if (kickTime >= 0 && System.currentTimeMillis() > Constants.afkTimestamps.get(u) + kickTime) {
+            if (kickTime >= 0 && now > Constants.afkTimestamps.get(u) + kickTime) {
+                if (player.hasPermission("nickafkpartypack.op.nokick")) continue;
                 player.kickPlayer("You have been AFK for too long.");
-            } else if (afkTime >= 0 && System.currentTimeMillis() > Constants.afkTimestamps.get(u) + afkTime) {
+            } else if (afkTime >= 0 && now > Constants.afkTimestamps.get(u) + afkTime) {
                 Tasks.setAfk(player, true);
             }
         }

--- a/src/main/java/ml/noahc3/nickafkpartypack/Packets/AbstractPacket.java
+++ b/src/main/java/ml/noahc3/nickafkpartypack/Packets/AbstractPacket.java
@@ -49,7 +49,7 @@ public abstract class AbstractPacket {
         try {
             ProtocolLibrary.getProtocolManager().sendServerPacket(receiver,
                     getHandle());
-        } catch (InvocationTargetException e) {
+        } catch (Exception e) {
             throw new RuntimeException("Cannot send packet.", e);
         }
     }
@@ -72,7 +72,7 @@ public abstract class AbstractPacket {
     @Deprecated
     public void recievePacket(Player sender) {
         try {
-            ProtocolLibrary.getProtocolManager().recieveClientPacket(sender,
+            ProtocolLibrary.getProtocolManager().receiveClientPacket(sender,
                     getHandle());
         } catch (Exception e) {
             throw new RuntimeException("Cannot recieve packet.", e);
@@ -87,7 +87,7 @@ public abstract class AbstractPacket {
      */
     public void receivePacket(Player sender) {
         try {
-            ProtocolLibrary.getProtocolManager().recieveClientPacket(sender,
+            ProtocolLibrary.getProtocolManager().receiveClientPacket(sender,
                     getHandle());
         } catch (Exception e) {
             throw new RuntimeException("Cannot receive packet.", e);

--- a/src/main/java/ml/noahc3/nickafkpartypack/Packets/AbstractPacket.java
+++ b/src/main/java/ml/noahc3/nickafkpartypack/Packets/AbstractPacket.java
@@ -1,7 +1,5 @@
 package ml.noahc3.nickafkpartypack.Packets;
 
-import java.lang.reflect.InvocationTargetException;
-
 import org.bukkit.entity.Player;
 
 import com.comphenix.protocol.PacketType;

--- a/src/main/java/ml/noahc3/nickafkpartypack/Packets/PacketListener.java
+++ b/src/main/java/ml/noahc3/nickafkpartypack/Packets/PacketListener.java
@@ -16,6 +16,7 @@ import org.bukkit.entity.Player;
 import java.util.Collections;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class PacketListener {
     private static PacketAdapter playServerPlayerInfo;
@@ -23,11 +24,11 @@ public class PacketListener {
         playServerPlayerInfo = new PacketAdapter(Constants.plugin, PacketType.Play.Server.PLAYER_INFO) {
             @Override
             public void onPacketSending(PacketEvent event) {
-                if (event.getPacket().getPlayerInfoAction().read(0) != EnumWrappers.PlayerInfoAction.ADD_PLAYER) return;
-
+                Set<EnumWrappers.PlayerInfoAction> actions = event.getPacket().getPlayerInfoActions().read(0);
+                if (!actions.contains(EnumWrappers.PlayerInfoAction.ADD_PLAYER)) return;
                 boolean bShowAfkTagOverHeads = Constants.config.getBoolean("show-afk-tag-over-heads");
                 List<PlayerInfoData> newPlayerInfoDataList = new ArrayList<>();
-                List<PlayerInfoData> playerInfoDataList = event.getPacket().getPlayerInfoDataLists().read(0);
+                List<PlayerInfoData> playerInfoDataList = event.getPacket().getPlayerInfoDataLists().read(1);
                 for (PlayerInfoData pid : playerInfoDataList) {
                     PlayerInfoData newPid = null;
                     WrappedGameProfile profile = pid != null ? pid.getProfile() : null;
@@ -46,7 +47,7 @@ public class PacketListener {
                      }
                      newPlayerInfoDataList.add(newPid != null ? newPid : pid);
                 }
-                event.getPacket().getPlayerInfoDataLists().write(0, newPlayerInfoDataList);
+                event.getPacket().getPlayerInfoDataLists().write(1, newPlayerInfoDataList);
             }
         };
 

--- a/src/main/java/ml/noahc3/nickafkpartypack/Packets/PacketListener.java
+++ b/src/main/java/ml/noahc3/nickafkpartypack/Packets/PacketListener.java
@@ -13,7 +13,6 @@ import ml.noahc3.nickafkpartypack.Util.Tasks;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
-import java.util.Collections;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -30,8 +29,9 @@ public class PacketListener {
                 List<PlayerInfoData> newPlayerInfoDataList = new ArrayList<>();
                 List<PlayerInfoData> playerInfoDataList = event.getPacket().getPlayerInfoDataLists().read(1);
                 for (PlayerInfoData pid : playerInfoDataList) {
-                    PlayerInfoData newPid = null;
-                    WrappedGameProfile profile = pid != null ? pid.getProfile() : null;
+                    if (pid == null) continue;
+                    WrappedGameProfile profile = pid.getProfile();
+                    PlayerInfoData newPid = pid;
                     if (profile != null) {
                         Player player = Bukkit.getPlayer(profile.getUUID());
 
@@ -45,7 +45,7 @@ public class PacketListener {
                         newProfile.getProperties().putAll(profile.getProperties());
                         newPid = new PlayerInfoData(newProfile, pid.getLatency(), pid.getGameMode(), WrappedChatComponent.fromText(fullName));
                      }
-                     newPlayerInfoDataList.add(newPid != null ? newPid : pid);
+                     newPlayerInfoDataList.add(newPid);
                 }
                 event.getPacket().getPlayerInfoDataLists().write(1, newPlayerInfoDataList);
             }

--- a/src/main/java/ml/noahc3/nickafkpartypack/Packets/PacketListener.java
+++ b/src/main/java/ml/noahc3/nickafkpartypack/Packets/PacketListener.java
@@ -25,7 +25,7 @@ public class PacketListener {
             @Override
             public void onPacketSending(PacketEvent event) {
                 Set<EnumWrappers.PlayerInfoAction> actions = event.getPacket().getPlayerInfoActions().read(0);
-                if (!actions.contains(EnumWrappers.PlayerInfoAction.ADD_PLAYER)) return;
+                if (!actions.contains(EnumWrappers.PlayerInfoAction.ADD_PLAYER) && !actions.contains(EnumWrappers.PlayerInfoAction.UPDATE_DISPLAY_NAME)) return;
                 boolean bShowAfkTagOverHeads = Constants.config.getBoolean("show-afk-tag-over-heads");
                 List<PlayerInfoData> newPlayerInfoDataList = new ArrayList<>();
                 List<PlayerInfoData> playerInfoDataList = event.getPacket().getPlayerInfoDataLists().read(1);

--- a/src/main/java/ml/noahc3/nickafkpartypack/Packets/WrapperPlayServerPlayerInfo.java
+++ b/src/main/java/ml/noahc3/nickafkpartypack/Packets/WrapperPlayServerPlayerInfo.java
@@ -1,6 +1,7 @@
 package ml.noahc3.nickafkpartypack.Packets;
 
 import java.util.List;
+import java.util.Set;
 
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.PacketContainer;
@@ -19,19 +20,19 @@ public class WrapperPlayServerPlayerInfo extends AbstractPacket {
         super(packet, TYPE);
     }
 
-    public PlayerInfoAction getAction() {
-        return handle.getPlayerInfoAction().read(0);
+    public Set<PlayerInfoAction> getAction() {
+        return handle.getPlayerInfoActions().read(0);
     }
 
-    public void setAction(PlayerInfoAction value) {
-        handle.getPlayerInfoAction().write(0, value);
+    public void setAction(Set<PlayerInfoAction> value) {
+        handle.getPlayerInfoActions().write(0, value);
     }
 
     public List<PlayerInfoData> getData() {
-        return handle.getPlayerInfoDataLists().read(0);
+        return handle.getPlayerInfoDataLists().read(1);
     }
 
     public void setData(List<PlayerInfoData> value) {
-        handle.getPlayerInfoDataLists().write(0, value);
+        handle.getPlayerInfoDataLists().write(1, value);
     }
 }

--- a/src/main/java/ml/noahc3/nickafkpartypack/Util/Tasks.java
+++ b/src/main/java/ml/noahc3/nickafkpartypack/Util/Tasks.java
@@ -1,5 +1,6 @@
 package ml.noahc3.nickafkpartypack.Util;
 
+import java.util.EnumSet;
 import com.comphenix.protocol.wrappers.EnumWrappers;
 import com.comphenix.protocol.wrappers.PlayerInfoData;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
@@ -17,20 +18,15 @@ public class Tasks {
     public static void refreshPlayer(Player player) {
         PlayerInfoData pid = new PlayerInfoData(WrappedGameProfile.fromPlayer(player), 1, EnumWrappers.NativeGameMode.SURVIVAL, WrappedChatComponent.fromText("..."));
 
-        WrapperPlayServerPlayerInfo remPacket = new WrapperPlayServerPlayerInfo();
-        remPacket.setAction(EnumWrappers.PlayerInfoAction.REMOVE_PLAYER);
-        remPacket.setData(Collections.singletonList(pid));
-
-        WrapperPlayServerPlayerInfo addPacket = new WrapperPlayServerPlayerInfo();
-        addPacket.setAction(EnumWrappers.PlayerInfoAction.ADD_PLAYER);
-        addPacket.setData(Collections.singletonList(pid));
+        WrapperPlayServerPlayerInfo updatePacket = new WrapperPlayServerPlayerInfo();
+        updatePacket.setAction(EnumSet.of(EnumWrappers.PlayerInfoAction.ADD_PLAYER));
+        updatePacket.setData(Collections.singletonList(pid));
 
         for(Player p : Bukkit.getOnlinePlayers())
         {
             p.hidePlayer(Constants.plugin, player);
-            remPacket.sendPacket(p);
+            updatePacket.sendPacket(p);
             p.showPlayer(Constants.plugin, player);
-            addPacket.sendPacket(p);
         }
     }
 

--- a/src/main/java/ml/noahc3/nickafkpartypack/Util/Tasks.java
+++ b/src/main/java/ml/noahc3/nickafkpartypack/Util/Tasks.java
@@ -1,6 +1,5 @@
 package ml.noahc3.nickafkpartypack.Util;
 
-import java.util.EnumSet;
 import com.comphenix.protocol.wrappers.EnumWrappers;
 import com.comphenix.protocol.wrappers.PlayerInfoData;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
@@ -13,6 +12,7 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
 import java.util.Collections;
+import java.util.EnumSet;
 
 public class Tasks {
     public static void refreshPlayer(Player player) {

--- a/src/main/java/ml/noahc3/nickafkpartypack/Util/Tasks.java
+++ b/src/main/java/ml/noahc3/nickafkpartypack/Util/Tasks.java
@@ -19,7 +19,11 @@ public class Tasks {
         PlayerInfoData pid = new PlayerInfoData(WrappedGameProfile.fromPlayer(player), 1, EnumWrappers.NativeGameMode.SURVIVAL, WrappedChatComponent.fromText("..."));
 
         WrapperPlayServerPlayerInfo updatePacket = new WrapperPlayServerPlayerInfo();
-        updatePacket.setAction(EnumSet.of(EnumWrappers.PlayerInfoAction.ADD_PLAYER));
+        EnumSet<EnumWrappers.PlayerInfoAction> actions = EnumSet.of(
+            EnumWrappers.PlayerInfoAction.ADD_PLAYER,
+            EnumWrappers.PlayerInfoAction.UPDATE_LISTED,
+            EnumWrappers.PlayerInfoAction.UPDATE_DISPLAY_NAME);
+        updatePacket.setAction(actions);
         updatePacket.setData(Collections.singletonList(pid));
 
         for(Player p : Bukkit.getOnlinePlayers())

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: NickAfkPartyPack
-version: 1.0.3
+version: 1.0.4
 main: ml.noahc3.nickafkpartypack.NickAfkPartyPack
-api-version: 1.18
+api-version: 1.19.3
 author: noahc3
 website: https://www.curseforge.com/minecraft/bukkit-plugins/nick-afk-party-pack
 depend: [ProtocolLib]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -69,6 +69,9 @@ permissions:
   nickafkpartypack.op.reload:
     description: Permission to use /nickafkreload.
     default: op
+  nickafkpartypack.op.nokick:
+    description: Disable AFK auto kick for operator.
+    default: op
   nickafkpartypack.player.*:
     description: Wildcard permission for all player command permissions
     children:
@@ -82,6 +85,7 @@ permissions:
       nickafkpartypack.op.setothernick: true
       nickafkpartypack.op.delothernick: true
       nickafkpartypack.op.reload: true
+      nickafkpartypack.op.nokick: true
   nickafkpartypack.*:
     description: Wildcard permission for all player and operator command permissions
     children:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: NickAfkPartyPack
 version: 1.0.4
 main: ml.noahc3.nickafkpartypack.NickAfkPartyPack
-api-version: 1.19.3
+api-version: 1.18
 author: noahc3
 website: https://www.curseforge.com/minecraft/bukkit-plugins/nick-afk-party-pack
 depend: [ProtocolLib]


### PR DESCRIPTION
1.19.3 に対応するために ProtocolLib 5.0.0-SNAPSHOT に移行しました。[ProtocolLib 4.8.0](https://www.spigotmc.org/resources/protocollib.1997/) では動作しません。
[ProtocolLib 5.0.0 latest dev build](https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/) を使用してください。
2022/12/17 時点では、この PR をビルドすると、シンボルが解決できないエラーが発生します。
ProtocolLib をローカルで `mvn package && mvn publish` しておく必要があります。
